### PR TITLE
Raise error upon embeds and hidden message

### DIFF
--- a/discord/ext/slash/__init__.py
+++ b/discord/ext/slash/__init__.py
@@ -463,6 +463,8 @@ class Context(discord.Object, _AsyncInit):
             embeds = [embed]
         if embeds:
             embeds = [emb.to_dict() for emb, _ in zip(embeds, range(10))]
+        if embeds and ephemeral:
+            raise TypeError('Ephemeral messages do not currently support embeds. See: https://github.com/discord/discord-api-docs/issues/2318')
         mentions = self.client.allowed_mentions
         if mentions is not None and allowed_mentions is not None:
             mentions = mentions.merge(allowed_mentions)


### PR DESCRIPTION
https://github.com/discord/discord-api-docs/issues/2318 

Currently, you cannot send embeds with ephemeral messages. This prevents the API from raising an error, instead have the library raise it. You also may want to consider creating custom errors classes.